### PR TITLE
Keep blog list dates on one line

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -157,7 +157,14 @@ main.wrap, .home-wrap {
 .post-date {
   font-family: var(--font-display);
   color: var(--muted);
-  width: 84px;
+  /* "04 Sep 2024" measures 5.77em in Cabin Sketch, so 6em holds every date
+     on one line and keeps the column aligned. In em rather than px because
+     the date's font size changes per device — a fixed 84px column wrapped
+     as soon as the type scale grew. min-width, not width, so a fallback
+     face (Verdana needs 7.22em) pushes the column wider instead of
+     spilling into the title. */
+  min-width: 6em;
+  white-space: nowrap;
   flex: none;
 }
 .post-title, .post-list h2, .post-list h3 {
@@ -382,7 +389,6 @@ hr { border: none; border-top: 1px solid var(--line); margin: 32px 0; }
   margin: 0 0 8px;
 }
 .search-result { flex-wrap: wrap; }
-.search-result .post-date { width: 84px; }
 .search-snippet {
   flex: 1 1 100%;
   margin: 6px 0 0;
@@ -391,8 +397,9 @@ hr { border: none; border-top: 1px solid var(--line); margin: 32px 0; }
   color: var(--ink-2);
 }
 /* Only indent under the date column when the result has one (posts do,
-   writings don't), so the snippet always lines up with the title. */
-.post-date ~ .search-snippet { margin-left: 102px; }
+   writings don't), so the snippet always lines up with the title. Tracks
+   the 6em date column plus the 18px flex gap. */
+.post-date ~ .search-snippet { margin-left: calc(6em + 18px); }
 .search-snippet mark { background: none; color: var(--rust); font-weight: 600; }
 .search-empty { font-family: var(--font-serif); color: var(--muted); }
 
@@ -578,7 +585,10 @@ footer .wrap, .site-footer .wrap { font-size: 14.5px; }
   .site-nav, header nav { display: flex; gap: 18px; }
 
   /* The list row has to share a line with the date column on a ~390px
-     viewport, so these two run smaller than the phone scale above. */
-  .post-date { width: 74px; font-size: 14px; }
+     viewport, so these two run smaller than the phone scale above. The
+     column width comes from the 6em min-width, which at 14px is 84px —
+     narrower than the old fixed 74px would have been once dates stopped
+     wrapping. */
+  .post-date { font-size: 14px; }
   .post-title, .post-list h2, .post-list h3 { font-size: 21px; }
 }


### PR DESCRIPTION
Dates in the blog list were wrapping onto two lines.

## Cause

The date column was a fixed `width: 84px`, set when the theme had a single font size. After the per-device type scale landed, the date's font size varies from 14px to 21px depending on the device — but the column did not. `"04 Sep 2024"` measures 5.77em in Cabin Sketch, which is 87px at the desktop 15px, so **6 of 22 rows** were already wrapping.

## Fix

`min-width: 6em` + `white-space: nowrap` on `.post-date`:

- **`em`, not px** — the column tracks the date's own font size, so one declaration stays correct across all four scale blocks rather than needing a width per breakpoint.
- **`min-width`, not `width`** — if Cabin Sketch has not loaded, Verdana needs 7.22em; a fixed width would spill the date into the title, while min-width lets the column grow.

Headroom at every scale:

| scale | date size | column | needs |
|---|---|---|---|
| desktop | 15px | 90px | 87px |
| phone portrait | 14px | 84px | 81px |
| phone landscape | 17px | 102px | 98px |
| iPad portrait | 19px | 114px | 110px |
| iPad landscape | 21px | 126px | 121px |

## Follow-on changes

- `.search-result .post-date { width: 84px }` removed — it would have re-broken the same layout on the search page.
- The search snippet indent was hard-coded to `102px` (the old 84px column + 18px flex gap); it is now `calc(6em + 18px)` so it tracks the column.
- The mobile-portrait `width: 74px` is removed. It predated `nowrap` and would now cause overflow rather than a narrower column; the shared 6em gives 84px at that scale, leaving ~248px for the title on a 390px screen.

## Verification

Measured on a live render at desktop: 0 wrapped rows (down from 6), 0 overflowing, and all 22 columns resolving to an identical 90px so titles stay in a clean column.

One known imprecision: on the search page the title starts at 492px and the snippet at 495px. That `calc(6em + …)` resolves against the snippet's 15.5px font rather than the date's 15px, leaving a 3px offset — invisible in practice, but it is the one inexact number here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EXxogdBs47KEBZtQbyt4a1
