### PR TITLE
Reduce the phone type scale by 1px

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -541,37 +541,37 @@ footer .wrap, .site-footer .wrap { font-size: 14.5px; }
    held sideways. Both read at the same scale, 2px above desktop. */
 @media (max-width: 640px),
        (max-width: 1024px) and (max-height: 500px) {
-  body { font-size: 20px; }
-  .site-title, header h1 a, .site-title a { font-size: 32px; }
-  .site-tagline { font-size: 17px; }
-  .site-nav a, header nav a { font-size: 20px; }
-  .site-search input { font-size: 19px; }
+  body { font-size: 19px; }
+  .site-title, header h1 a, .site-title a { font-size: 31px; }
+  .site-tagline { font-size: 16px; }
+  .site-nav a, header nav a { font-size: 19px; }
+  .site-search input { font-size: 18px; }
 
   /* Landscape has room for the full-size list row; portrait doesn't,
      and shrinks these two further in the layout block below. */
-  .post-date { font-size: 17px; }
-  .post-title, .post-list h2, .post-list h3 { font-size: 23px; }
+  .post-date { font-size: 16px; }
+  .post-title, .post-list h2, .post-list h3 { font-size: 22px; }
 
-  .post h1, article h1 { font-size: 28px; }
-  .post h2, article h2 { font-size: 28px; }
-  .post h3, article h3 { font-size: 24px; }
-  .post h4, article h4 { font-size: 21px; }
-  .post .post-meta, article .post-meta { font-size: 17px; }
+  .post h1, article h1 { font-size: 27px; }
+  .post h2, article h2 { font-size: 27px; }
+  .post h3, article h3 { font-size: 23px; }
+  .post h4, article h4 { font-size: 20px; }
+  .post .post-meta, article .post-meta { font-size: 16px; }
 
   .post p, article p,
   .post ul, .post ol, article ul, article ol,
   .post table, article table,
-  blockquote { font-size: 22px; }
-  .post pre, article pre { font-size: 18px; }
+  blockquote { font-size: 21px; }
+  .post pre, article pre { font-size: 17px; }
 
-  .back-link { font-size: 20px; }
-  .credit, .postdate { font-size: 17px; }
-  .further-reading h3, .series-nav h3 { font-size: 19px; }
-  .post-pager { font-size: 17.5px; }
-  footer .wrap, .site-footer .wrap { font-size: 16.5px; }
-  .search-meta { font-size: 17px; }
-  .search-snippet { font-size: 17.5px; }
-  .search-empty { font-size: 18px; }
+  .back-link { font-size: 19px; }
+  .credit, .postdate { font-size: 16px; }
+  .further-reading h3, .series-nav h3 { font-size: 18px; }
+  .post-pager { font-size: 16.5px; }
+  footer .wrap, .site-footer .wrap { font-size: 15.5px; }
+  .search-meta { font-size: 16px; }
+  .search-snippet { font-size: 16.5px; }
+  .search-empty { font-size: 17px; }
 }
 
 /* ---------- phone portrait: layout ---------- */
@@ -589,6 +589,6 @@ footer .wrap, .site-footer .wrap { font-size: 14.5px; }
      column width comes from the 6em min-width, which at 14px is 84px —
      narrower than the old fixed 74px would have been once dates stopped
      wrapping. */
-  .post-date { font-size: 14px; }
-  .post-title, .post-list h2, .post-list h3 { font-size: 21px; }
+  .post-date { font-size: 13px; }
+  .post-title, .post-list h2, .post-list h3 { font-size: 20px; }
 }


### PR DESCRIPTION
Takes the phone type scale down 1px.

All 22 declarations in the phone block, plus the two phone-portrait list-row sizes:

| | before | after |
|---|---|---|
| prose | 22px | 21px |
| code blocks | 18px | 17px |
| body | 20px | 19px |
| h1 / h2 | 28px | 27px |
| list titles (portrait) | 21px | 20px |
| post dates (portrait) | 14px | 13px |

Portrait and landscape share the one block, so both move together.

## Verification

Resolved font sizes replayed across nine device profiles — only the two phone profiles changed:

```
desktop 1440                 prose=20px   identical
laptop 1280                  prose=20px   identical
iPad portrait 820            prose=24px   identical
iPad desktop-mode 980        prose=24px   identical
iPad landscape 1024          prose=26px   identical
iPad Pro 11 landscape 1194   prose=26px   identical
iPad Pro 12.9 landscape 1366 prose=26px   identical
phone portrait 390           prose=21px   -1px
phone landscape 844          prose=21px   -1px
```

The date column needed no adjustment: `min-width: 6em` resolves to 78px at the new 13px date size, against the 75px the text requires. A fixed-px column would have needed re-tuning here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EXxogdBs47KEBZtQbyt4a1
