### PR TITLE
Give phone landscape its own type scale

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -537,8 +537,10 @@ footer .wrap, .site-footer .wrap { font-size: 14.5px; }
 }
 
 /* ---------- phone ----------
-   Narrow portrait, or a short-and-wide viewport, which is a phone
-   held sideways. Both read at the same scale, 2px above desktop. */
+   Narrow portrait, or a short-and-wide viewport, which is a phone held
+   sideways. Both start from this scale; the landscape block below then
+   takes 2px off, since a sideways phone has ~390px of height for the
+   whole page and buys back vertical room by running smaller. */
 @media (max-width: 640px),
        (max-width: 1024px) and (max-height: 500px) {
   body { font-size: 19px; }
@@ -572,6 +574,42 @@ footer .wrap, .site-footer .wrap { font-size: 14.5px; }
   .search-meta { font-size: 16px; }
   .search-snippet { font-size: 16.5px; }
   .search-empty { font-size: 17px; }
+}
+
+/* ---------- phone, landscape ----------
+   2px below the portrait phone scale. Same short-viewport test as the
+   second clause above, so it only ever overrides the sideways case —
+   and it sits after that block, which is what makes it win. */
+@media (max-width: 1024px) and (max-height: 500px) {
+  body { font-size: 15px; }
+  .site-title, header h1 a, .site-title a { font-size: 27px; }
+  .site-tagline { font-size: 12px; }
+  .site-nav a, header nav a { font-size: 15px; }
+  .site-search input { font-size: 14px; }
+
+  .post-date { font-size: 12px; }
+  .post-title, .post-list h2, .post-list h3 { font-size: 18px; }
+
+  .post h1, article h1 { font-size: 23px; }
+  .post h2, article h2 { font-size: 23px; }
+  .post h3, article h3 { font-size: 19px; }
+  .post h4, article h4 { font-size: 16px; }
+  .post .post-meta, article .post-meta { font-size: 12px; }
+
+  .post p, article p,
+  .post ul, .post ol, article ul, article ol,
+  .post table, article table,
+  blockquote { font-size: 17px; }
+  .post pre, article pre { font-size: 13px; }
+
+  .back-link { font-size: 15px; }
+  .credit, .postdate { font-size: 12px; }
+  .further-reading h3, .series-nav h3 { font-size: 14px; }
+  .post-pager { font-size: 12.5px; }
+  footer .wrap, .site-footer .wrap { font-size: 11.5px; }
+  .search-meta { font-size: 12px; }
+  .search-snippet { font-size: 12.5px; }
+  .search-empty { font-size: 13px; }
 }
 
 /* ---------- phone portrait: layout ---------- */


### PR DESCRIPTION
Phones in landscape now have their own type scale, 4px below portrait.

## Why a new block

Portrait and landscape had been sharing a single block (`max-width: 640px, or max-width: 1024px and max-height: 500px`), so any change to one moved both. Landscape is now split out, reusing the same short-viewport test and placed immediately after the shared block — so it only ever overrides the sideways case, and wins by source order rather than by added specificity.

| | portrait | landscape |
|---|---|---|
| prose | 21px | 17px |
| code blocks | 17px | 13px |
| body | 19px | 15px |
| h1 / h2 | 27px | 23px |
| site title | 31px | 27px |

## Verification

Resolved font sizes replayed across eleven device profiles; only the two landscape phone profiles change:

```
desktop 1440                 prose=20px   identical
laptop 1280                  prose=20px   identical
iPad portrait 820            prose=24px   identical
iPad desktop-mode 980        prose=24px   identical
iPad landscape 1024          prose=26px   identical
iPad Pro 11 landscape 1194   prose=26px   identical
iPad Pro 12.9 landscape 1366 prose=26px   identical
phone portrait 390           prose=21px   identical
phone landscape 844          prose=17px   -4px
small phone landscape 568    prose=17px   -4px
iPhone SE portrait 375       prose=21px   identical
```

The edge case worth calling out: a small phone sideways (568x320) is narrow enough to match the `<=640px` portrait clause as well. It resolves to the landscape scale, which is correct, while an iPhone SE in portrait (375x667) stays on the portrait scale.

## Note

Landscape prose at 17px is now below the desktop scale (20px) and 3px under iPad. Code blocks at 13px are the smallest text in the theme. That is deliberate for a short viewport, but it is worth an eyeball on a real device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EXxogdBs47KEBZtQbyt4a1
